### PR TITLE
[RFC] Coding conventions updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Added
 
 - Add first draft of Code Standards Policy. [drybjed_]
 
+Changed
+~~~~~~~
+
+- Major rework and enhancement of Code Standards Policy. [ganto_]
+
 
 debops-policy v0.1.0 - 2016-09-04
 ---------------------------------

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -615,7 +615,7 @@ variable.
 Share configuration state with other roles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If a role need to know a configuration state of another role it MUST NOT access
+If a role needs to know a configuration state of another role it MUST NOT access
 inventory variables of the source role. This impedes the portability of a role
 and effectively makes the source role its hard dependency. Instead, roles SHOULD
 expose public data structures as needed for other roles to use as Ansible local

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -51,6 +51,13 @@ Summary
 
 Here's a basic set of principles to be aware while writing roles:
 
+- YAML files MUST use 2 space indents and end with ``.yml``.
+
+- Use spaces around Jinja variable syntax as in ``{{ var }}``.
+
+- When possible use 80 characters line width.
+
+
 **Ansible role: defaults**
 
 - Follow the :ref:`variable naming conventions <debops_policy__ref_code_standards_default_variable_naming_convention>`.
@@ -87,6 +94,8 @@ Here's a basic set of principles to be aware while writing roles:
 - :ref:`Disable debug mechanisms <debops_policy__ref_code_standards_task_disable_debug`
   such as the ``debug`` or ``ignore_errors`` statements in the ``master``
   branch.
+
+- Use tags to make individually usable tasks better accessible.
 
 
 **Ansible role: templates**
@@ -301,8 +310,8 @@ can be specified where the dependent variable is passed to the provider:
        - role: debops.nginx
 
 By including the configuration for the debops.apt_preferences_ role in the
-``nginx`` default variables the user to change it through the Ansible inventory
-without the need to modify any of the involved roles or the playbook.
+``nginx`` default variables the user is able to change it through the Ansible
+inventory without the need to modify any of the involved roles or the playbook.
 
 
 .. _debops_policy__ref_code_standards_inventory_level_scoped_variables:
@@ -367,8 +376,8 @@ Ansible role tasks
 ------------------
 
 Ansible tasks are doing the actual work namely querying and modifiying the
-target host. Each task defines a `Ansible Module <https://docs.ansible.com/ansible/modules.html>`_
-invocation with a number of general and module specific options.
+target host. Each task defines a `Ansible Module <Ansible Modules>` invocation
+with a number of general and module specific options.
 
 .. _debops_policy__ref_code_standards_task_description:
 
@@ -547,7 +556,7 @@ This is an example playbook for debops.slapd_ defining soft dependencies:
 
         - role: debops.tcpwrappers
           tags: [ 'role::tcpwrappers' ]
-          tcpwrappers_dependent_allow:
+          tcpwrappers__dependent_allow:
             - '{{ slapd__tcpwrappers__dependent_allow }}'
 
         - role: debops.slapd

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -502,7 +502,7 @@ for normal operations. Released code is expected to be functional under every
 possible circumstance otherwise it is considered to be a bug which must be
 fixed on a best effort basis.
 
-For fragile or complex code paths it might be acceptable to to use the
+For fragile or complex code paths it might be acceptable to use the
 ``debug`` statement with an increased ``verbosity`` level. This will only show
 the message, if :program:`ansible-playbook` is executed with one or more
 ``--verbose`` options. For example:

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -270,7 +270,9 @@ Description
 
 Each task MUST have the ``name`` option set with a meaningful description. This
 allows to quickly reason about the change impact when running a playbook and
-classify the progress in case of an abortion. Example:
+classify the progress in case of an abortion.
+
+**Example:**
 
 .. code-block:: yaml
 
@@ -281,7 +283,9 @@ classify the progress in case of an abortion. Example:
 
 The same is true for the ``include`` statement. Especially for conditional
 includes which may be skipped it's helpful for identifying which features of
-the role have been left out. Example:
+the role have been left out.
+
+**Example:**
 
 .. code-block:: yaml
 

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -7,7 +7,7 @@ DebOps Code Standards Policy
 
 :Date drafted: 2016-11-05
 :Date effective: 2017-01-01
-:Last changed: 2016-11-17
+:Last changed: 2016-11-23
 :Version: 0.1.0
 :Authors: - drybjed_
           - ypid_

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -79,6 +79,10 @@ Summary
 - Set a minimal Ansible version in :file:`meta/main.yml` according to the
   modules and task parameters used.
 
+- :ref:`Disable debug mechanisms <debops_policy__ref_code_standards_task_disable_debug`
+  such as the ``debug`` or ``ignore_errors`` statements in the ``master``
+  branch.
+
 
 **Ansible role: templates**
 
@@ -144,11 +148,6 @@ Here's the basic set of principles to be aware while writing roles:
   needed for other roles to use as Ansible local facts; this should ensure that the
   data used by other roles is available at all times, and therefore idempotent.
 
-- roles MUST NOT use Ansible debug mechanisms such as ``debug`` and
-  ``ignore_errors`` modules/module parameters for normal operations. If
-  during development or normal operation a role consistently experiences
-  issues, they should be fixed or handled conditionally instead of being
-  ignored.
 
 
 .. _debops_policy__ref_code_standards_role_default_variables:
@@ -438,6 +437,29 @@ Instead of ...
      file:
        path: '{{ elasticsearch__path_plugins }}'
        state: directory
+
+.. _debops_policy__ref_code_standards_task_disable_debug:
+
+Disable debug statements
+------------------------
+
+Role authors MUST NOT unconditionally use Ansible debug mechanisms such as the
+``debug`` module or the ``ignore_errors`` task statement in code which is used
+for normal operations. Released code is expected to be functional under every
+possible circumstance otherwise it is considered to be a bug which must be
+fixed on a best effort basis.
+
+For fragile or complex code paths it might be acceptable to to use the
+``debug`` statement with an increased ``verbosity`` level. This will only show
+the message, if :program:`ansible-playbook` is executed with one or more
+``--verbose`` options. For example:
+
+.. code-block:: yaml
+
+   - name: Show intermediate value from a lookup query
+     debug:
+       var: '{{ lookup("template", "lookups/fancy_lookup.j2") }}'
+       verbosity: 1
 
 
 .. _debops_policy__ref_code_standards_role_dependencies:

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -62,7 +62,7 @@ Here's a basic set of principles to be aware while writing roles:
 
 - Follow the :ref:`variable naming conventions <debops_policy__ref_code_standards_default_variable_naming_convention>`.
 
-- Make :ref:`conditional code configurable <_debops_policy__ref_code_standards_task_conditions>`
+- Make :ref:`conditional code configurable <debops_policy__ref_code_standards_task_conditions>`
   via default variables.
 
 - :ref:`Comment and structure <debops_policy__ref_code_standards_default_variable_documentation>`
@@ -82,7 +82,7 @@ Here's a basic set of principles to be aware while writing roles:
 - :ref:`Describe each task and include <debops_policy__ref_code_standards_task_description>`
   with the ``name`` option.
 
-- Use native :ref:`YAML syntax <debops_policy__ref_code_standards_task_yaml_syntax`
+- Use native :ref:`YAML syntax <debops_policy__ref_code_standards_task_yaml_syntax>`
   for task definition formatting.
 
 - If some tasks should only be executed under certain circumstances, group them
@@ -91,7 +91,7 @@ Here's a basic set of principles to be aware while writing roles:
 - Set a minimal Ansible version in :file:`meta/main.yml` according to the
   modules and task parameters used.
 
-- :ref:`Disable debug mechanisms <debops_policy__ref_code_standards_task_disable_debug`
+- :ref:`Disable debug mechanisms <debops_policy__ref_code_standards_task_disable_debug>`
   such as the ``debug`` or ``ignore_errors`` statements in the ``master``
   branch.
 
@@ -108,7 +108,7 @@ Here's a basic set of principles to be aware while writing roles:
 
 **Ansible role: dependencies**
 
-- Define role dependencies as :ref:`"soft" dependencies <debops_policy__ref_code_standards_soft_dependencies>`
+- Define role dependencies as :ref:`"soft" dependencies <debops_policy__ref_code_standards_soft_role_dependencies>`
   via playbook and make them conditional if possible.
 
 - Avoid the use of :ref:`"hard" role dependencies <debops_policy__ref_code_standards_hard_role_dependencies>`
@@ -600,7 +600,7 @@ Ansible facts are small things that are automatically discovered by the
 be used by Ansible role and playbook authors through normal variables. The
 default facts provided are indicated by the ``ansible_`` namespace. It's
 possible to define custom facts through JSON or INI files or scripts returning
-such output in the :path:`/etc/ansible/facts.d` directory of a host. These
+such output in the :file:`/etc/ansible/facts.d` directory of a host. These
 facts are then available as key/value pairs under the ``ansible_local``
 variable.
 

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -528,7 +528,7 @@ Soft role dependencies
 
 Role dependencies are considered "soft" if they are defined in the ``roles``
 list of a playbook. This approach offers a higher flexibility as the user can
-choose which playbooks to run and which features to include.
+choose which roles to run and which features to include.
 
 Whenever possible DebOps role authors MUST specify role dependencies via
 playbook instead of
@@ -583,7 +583,7 @@ avoid the use of hard role dependencies for the following reasons:
 
 - It hinders the independent use of the role in a custom playbook or outside
   of DebOps where playbook authors might relay on a different role for a certain
-  feature or decide no to use a certain feature at all.
+  feature or decide not to use a certain feature at all.
 
 - The playbook execution flow is more difficult to reason about as hard
   dependencies are defined outside of the playbook.
@@ -593,7 +593,7 @@ Generally role dependencies MUST be defined as
 via playbook unless the tight coupling to another role is unavoidable for
 implementing the required functionality. A reasonable exception is for example
 the debops.secret_ role which defines a common path for the
-``lookup("password")`` module.
+``lookup("password")`` plugin.
 
 
 .. _debops_policy__ref_code_standards_role_facts:

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -196,7 +196,7 @@ Variable documentation
 For each role the `DebOps Documentation`_ will include a page which
 documents the default variables. This page is generated from the role's
 :file:`defaults/main.yml` file with help of yaml2rst_. The entire comment of
-the defauls file is thereby interpreted as reStructuredText_ and then rendered
+the defaults file is thereby interpreted as reStructuredText_ and then rendered
 via Sphinx_.
 
 Each variable comment is started with a ``.. envvar::`` reference anchor
@@ -375,7 +375,7 @@ level inventory variable in (e.g.
 Ansible role tasks
 ------------------
 
-Ansible tasks are doing the actual work namely querying and modifiying the
+Ansible tasks are doing the actual work namely querying and modifying the
 target host. Each task defines a `Ansible Module <Ansible Modules>` invocation
 with a number of general and module specific options.
 
@@ -417,7 +417,7 @@ Conditions
 
 It might be necessary often that task execution might depend on a certain
 condition using the ``when`` statement. In many cases the condition is simple
-and straight forward, for example when depending on the existance of a file.
+and straight forward, for example when depending on the existence of a file.
 Other times the condition might be more complex, for example when depending
 on a state of other role configurations. In this case the expression SHOULD
 be defined in a default variable. This would give the user the ability to
@@ -459,7 +459,7 @@ YAML syntax
 
 Task definitions MUST use the native YAML syntax formatting. Ansible accepts
 various ways to define Ansible tasks. However, there are several advantages by
-agreening on the YAML syntax:
+agreeing on the YAML syntax:
 
 - Unified coding style
 
@@ -570,7 +570,7 @@ Hard role dependencies
 
 Role dependencies are considered "hard" if they are defined in the
 ``dependencies`` list in :file:`meta/main.yml`.  DebOps role authors MUST
-avoid the use of hard role dependencies for the follwing reasons:
+avoid the use of hard role dependencies for the following reasons:
 
 - Hard role dependencies must always be installed on the Ansible controller
   even when their execution is conditionally triggered via ``when`` statement.
@@ -647,4 +647,3 @@ The debops.ferm_ role itself defines the facts via a Jinja2 template such as:
    "forward": "{{ ferm__tpl_forward | bool | lower }}",
    "ansible_controllers": {{ ferm__tpl_ansible_controllers_result | to_nice_json }}
    }
-

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -15,12 +15,18 @@ DebOps Code Standards Policy
 
 .. This version may not correspond directly to the debops-policy version.
 
+
+.. _debops_policy__ref_code_standards_terminology:
+
 Terminology
 -----------
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in BCP 14, [`RFC2119`_].
+
+
+.. _debops_policy__ref_code_standards_goals:
 
 Goals of the Policy
 -------------------
@@ -37,17 +43,20 @@ This Policy describes how the Ansible roles and playbooks should be written,
 what ways can be used to combine two or more roles together and how the roles
 should be documented.
 
+
+.. _debops_policy__ref_code_standards_summary:
+
 Summary
 -------
 
 **Ansible role: defaults**
 
-- Follow the :ref:`variable naming conventions <policy__ref_default_variable_naming_convention>`.
+- Follow the :ref:`variable naming conventions <debops_policy__ref_code_standards_default_variable_naming_convention>`.
 
-- Make :ref:`conditional code configurable <_policy__ref_task_conditions>` via
-  default variables.
+- Make :ref:`conditional code configurable <_debops_policy__ref_code_standards_task_conditions>`
+  via default variables.
 
-- :ref:`Comment and structure <policy__ref_default_variable_documentation>`
+- :ref:`Comment and structure <debops_policy__ref_code_standards_default_variable_documentation>`
   default variables with reStructuredText.
 
 
@@ -55,8 +64,8 @@ Summary
 
 - Make sure the task execution is idempotent.
 
-- :ref:`Describe each task and include <policy__ref_task_description>` with the
-  ``name`` option.
+- :ref:`Describe each task and include <debops_policy__ref_code_standards_task_description>`
+  with the ``name`` option.
 
 - Use native YAML syntax for task definition.
 
@@ -145,10 +154,12 @@ Here's the basic set of principles to be aware while writing roles:
   ignored.
 
 
+.. _debops_policy__ref_code_standards_role_default_variables:
+
 Ansible role default variables
 ------------------------------
 
-.. _policy__ref_default_variable_naming_convention:
+.. _debops_policy__ref_code_standards_default_variable_naming_convention:
 
 Naming convention
 ~~~~~~~~~~~~~~~~~
@@ -204,7 +215,7 @@ By including the configuration for the debops.apt_preferences_ role in your role
 default variables you allow the user to change it through the Ansible inventory
 without the need to modify any of the involved roles or the playbook.
 
-.. _policy__ref_default_variable_documentation:
+.. _debops_policy__ref_code_standards_default_variable_documentation:
 
 Variable documentation
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -253,6 +264,9 @@ might be meaningful for the individual role:
     [... networking related variables ...]
                                                                    # ]]]
 
+
+.. _debops_policy__ref_code_standards_role_tasks:
+
 Ansible role tasks
 ------------------
 
@@ -260,7 +274,7 @@ Ansible tasks are doing the actual work namely querying and modifiying the
 target host. Each task defines a `Ansible Module <https://docs.ansible.com/ansible/modules.html>`_
 invocation with a number of general and module specific options.
 
-.. _policy__ref_task_description:
+.. _debops_policy__ref_code_standards_task_description:
 
 Description
 ~~~~~~~~~~~
@@ -291,7 +305,7 @@ the role have been left out.
       when: (pki__enabled|bool and
              (pki__acme|bool or pki__acme_install|bool))
 
-.. _policy__ref_task_conditions:
+.. _debops_policy__ref_code_standards_task_conditions:
 
 Conditions
 ~~~~~~~~~~

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -421,7 +421,7 @@ the role have been left out.
 Conditions
 ~~~~~~~~~~
 
-It might be necessary often that task execution might depend on a certain
+It might be often necessary that task execution depends on a certain
 condition using the ``when`` statement. In many cases the condition is simple
 and straight forward, for example when depending on the existence of a file.
 Other times the condition might be more complex, for example when depending

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -49,6 +49,8 @@ should be documented.
 Summary
 -------
 
+Here's a basic set of principles to be aware while writing roles:
+
 **Ansible role: defaults**
 
 - Follow the :ref:`variable naming conventions <debops_policy__ref_code_standards_default_variable_naming_convention>`.
@@ -111,7 +113,6 @@ Summary
   be extended by dependent roles.
 
 
-
 Ansible role overview
 ---------------------
 
@@ -122,22 +123,13 @@ inventory without a requirement to modify the role's code as well as offer the
 most amount of reusability so that other Ansible roles can utilize them if
 necessary.
 
-Here's the basic set of principles to be aware while writing roles:
-
-
-- each role SHOULD focus on a specific service or application. Roles can be
-  composed together inside playbooks if needed, so there's no need to put
-  different services together in the same role.
-  A exception here are very similar services like the different NTP daemons.
-  This has the advantage to only having one set of default variables regardless
-  of the particular chosen service and it makes changing the particular service
-  every easy.
-
-- roles SHOULD use Ansible local facts stored on the hosts to keep their
-  internal state consistent and idempotent at all times, no matter if the role
-  is used standalone or a part of another role's playbook. The facts can be
-  either static or dynamically generated, or a combination of the two.
-
+Each role SHOULD focus on a specific service or application. Roles can be
+composed together inside playbooks if needed, so there's no need to put
+different services together in the same role.
+An exception here are very similar services like the different NTP daemons.
+This has the advantage to only having one set of default variables regardless
+of the particular chosen service and it makes changing the particular service
+every easy.
 
 
 .. _debops_policy__ref_code_standards_role_default_variables:
@@ -239,7 +231,7 @@ might be meaningful for the individual role:
 .. _debops_policy__ref_code_standards_dependent_variables:
 
 Dependent variables
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 DebOps is designed in a way that there are divided responsibilities between the
 roles. Each role has its clear task to fulfill. For example an application role
@@ -312,10 +304,11 @@ By including the configuration for the debops.apt_preferences_ role in the
 ``nginx`` default variables the user to change it through the Ansible inventory
 without the need to modify any of the involved roles or the playbook.
 
+
 .. _debops_policy__ref_code_standards_inventory_level_scoped_variables:
 
 Inventory level scoped variables
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Ansible inventory allows managing hosts, such as executing playbooks or
 scoping variables, in three different levels:
@@ -485,7 +478,7 @@ Instead of ...
 .. _debops_policy__ref_code_standards_task_disable_debug:
 
 Disable debug statements
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 Role authors MUST NOT unconditionally use Ansible debug mechanisms such as the
 ``debug`` module or the ``ignore_errors`` task statement in code which is used
@@ -507,6 +500,7 @@ the message, if :program:`ansible-playbook` is executed with one or more
 
 
 .. _debops_policy__ref_code_standards_role_dependencies:
+
 
 Ansible role dependencies
 -------------------------

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -70,7 +70,8 @@ Summary
 - :ref:`Describe each task and include <debops_policy__ref_code_standards_task_description>`
   with the ``name`` option.
 
-- Use native YAML syntax for task definition.
+- Use native :ref:`YAML syntax <debops_policy__ref_code_standards_task_yaml_syntax`
+  for task definition formatting.
 
 - If some tasks should only be executed under certain circumstances, group them
   together and conditionally include the task list.
@@ -404,6 +405,39 @@ current state. The related default variable is defined in
 If the user doesn't agree with the defined condition, the variable can simply
 be redefined in the Ansible inventory without the need to modify the Ansible
 code of the role.
+
+.. _debops_policy__ref_code_standards_task_yaml_syntax:
+
+YAML syntax
+~~~~~~~~~~~
+
+Task definitions MUST use the native YAML syntax formatting. Ansible accepts
+various ways to define Ansible tasks. However, there are several advantages by
+agreening on the YAML syntax:
+
+- Unified coding style
+
+- Vertical formatting is easier to read
+
+- Supports complex parameter values (e.g. nested dictionaries)
+
+**Example:**
+
+Instead of ...
+
+.. code-block:: yaml
+
+   - name: Create plugin path
+     file: path={{ elasticsearch__path_plugins }} state=directory
+
+... use the correct YAML syntax:
+
+.. code-block:: yaml
+
+   - name: Create plugin path
+     file:
+       path: '{{ elasticsearch__path_plugins }}'
+       state: directory
 
 
 .. _debops_policy__ref_code_standards_role_dependencies:

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -489,7 +489,7 @@ Instead of ...
    - name: Create plugin path
      file:
        path: '{{ elasticsearch__path_plugins }}'
-       state: directory
+       state: 'directory'
 
 .. _debops_policy__ref_code_standards_task_disable_debug:
 

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -541,6 +541,11 @@ involved role is offering dedicated
 for this purpose. With soft dependencies custom playbook authors are therefore
 free to pass values from arbitrary sources according to their requirements.
 
+When a role that is used as a soft dependency already contains its own
+dependencies, all of them SHOULD be included in the playbook to ensure that the
+required functionality (firewall access, APT preferences, etc.) is provided and
+configured as needed by the dependent role.
+
 **Example:**
 
 This is an example playbook for debops.slapd_ defining soft dependencies:
@@ -582,7 +587,7 @@ avoid the use of hard role dependencies for the following reasons:
   even when their execution is conditionally triggered via ``when`` statement.
 
 - It hinders the independent use of the role in a custom playbook or outside
-  of DebOps where playbook authors might relay on a different role for a certain
+  of DebOps where playbook authors might rely on a different role for a certain
   feature or decide not to use a certain feature at all.
 
 - The playbook execution flow is more difficult to reason about as hard

--- a/docs/code-standards-policy.rst
+++ b/docs/code-standards-policy.rst
@@ -186,6 +186,7 @@ consume role name. E.g.
    nginx__apt_preferences__dependent_list:
      - package: 'nginx nginx-*'
        backports: [ 'wheezy', 'precise' ]
+       by_role: 'debops.nginx'
 
 
 .. _debops_policy__ref_code_standards_default_variable_documentation:
@@ -268,6 +269,10 @@ configuration. The provider role SHOULD then manage an individual configuration
 file per list item which allows it to selectively add or remove configuration
 states.
 
+Additionally, the ``by_role`` property (string) SHOULD be accepted which can be
+used to indicate the role responsible for a given item.
+``by_role`` MUST be given in the from of ``ROLE_OWNER.ROLE_NAME``.
+
 **Example:**
 
 The debops.apt_preferences_ role implements a feature to set APT package
@@ -291,6 +296,7 @@ which defines the necessary pinning information:
    nginx__apt_preferences__dependent_list:
      - package: 'nginx nginx-*'
        backports: [ 'wheezy', 'precise' ]
+       by_role: 'debops.nginx'
 
 In the playbook a :ref:`soft dependency <debops_policy__ref_code_standards_soft_role_dependencies>`
 can be specified where the dependent variable is passed to the provider:


### PR DESCRIPTION
After the recent discussions I felt I should spend some time to clarify the current coding conventions and also restructure and extend them a bit.

I therefore started a new layout by introducing a new "Summary" section right on top. Ideally each point there would link to a section below which would explain it in more details and with examples (similar to what's already there with the naming conventions). I added some example topics that I felt confident enough to write down. I hope that most of the new content is already according to our common "informal" conventions, but of course I'm fine discussing all the extensions.

I didn't spent time yet to rework the "Ansible role overview" content as I first wanted to know if you agree with this procedure. Certainly most points there should be moved into a closer related section.

Let me know what you think. If you agree more or less, I would invest more time to get all my thoughts about this topic into this policy.